### PR TITLE
Prevent first whitelisted user being ignored

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -59,7 +59,7 @@ class store extends php_obj implements log_writer {
      */
     public function __construct(log_manager $manager) {
         $this->helper_setup($manager);
-        
+
     }
 
     /**
@@ -77,7 +77,7 @@ class store extends php_obj implements log_writer {
 
                 $checkstring = ",".$user.",";
 
-                if (strpos($list, $checkstring)) {
+                if (strpos($list, $checkstring) !== false) {
                     return false;
                   }
                   else {


### PR DESCRIPTION
Whitelisting doesn't appear to work for the first user in the list. This patch just tightens up the string comparison so that a value of zero isn't counted as the user not being in the list.
